### PR TITLE
Create adjust-and-extract-ground.json

### DIFF
--- a/adjust-and-extract-ground.json
+++ b/adjust-and-extract-ground.json
@@ -1,0 +1,37 @@
+{
+    "pipeline": [
+        {
+            "type":"readers.las"
+        },
+        {
+          "type":"filters.transformation",
+          "matrix":"1 0 0 Tx  0 1 0 Ty  0 0 1 Tz  0 0 0 1"
+        },
+        {
+            "tag":"adjusted",
+            "type": "writers.las",
+            "compression": "true"
+        },
+        {
+          "type":"filters.range",
+          "limits":"NumberOfReturns[1:7],ReturnNumber[1:7]"
+        },
+        {
+            "type":"filters.smrf"
+        },
+        {
+            "type":"filters.range",
+            "limits":"Classification[2:2]"
+        },
+        {
+            "tag":"ground",
+            "type": "writers.las",
+            "compression": "true"
+        },
+        {
+            "type":"writers.gdal",
+            "resolution":0.82,
+            "output_type":"min"
+        }
+    ]
+}


### PR DESCRIPTION
A pipeline to adjust to control, extract ground points, and write adjusted laz, ground laz, and geotiffs for each record. Some notes for discussion: 

1. Currently Tx, Ty, and Tz come from the point query utility in QT and from manually inspecting the point cloud. We should eventually automate this process. If there is no need to adjust the points, you can either replace the Tx, Ty, Tz with 0, or you can remove that section all together.

2. We run smrf in the cleaning pipeline, so I think we can probably remove it from this pipeline.

3. This currently writes a geotiff for each record. We are moving toward tiled geotiffs. So this will hopefully become obsolete in the near future.

4. As with any pipeline, not all values are universal. Check that the values for each property are desirable for your pipeline before use.